### PR TITLE
Refactor backend auth to use express-session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "cookie-parser": "^1.4.6",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-session": "^1.17.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.2",
@@ -2898,26 +2898,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "dependencies": {
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -3459,6 +3439,45 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "dependencies": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -4678,7 +4697,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -5024,6 +5042,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/randombytes": {
@@ -6041,6 +6067,17 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undefsafe": {
@@ -8731,22 +8768,6 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
-    "cookie-parser": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
-      "requires": {
-        "cookie": "0.4.1",
-        "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-        }
-      }
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -9146,6 +9167,41 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.3.tgz",
+      "integrity": "sha512-4+otWXlShYlG1Ma+2Jnn+xgKUZTMJ5QD3YvfilX3AcocOAbIkVylSWEklzALe/+Pu4qV6TYBj5GwOBFfdKqLBw==",
+      "requires": {
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -10042,8 +10098,7 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
-      "dev": true
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",
@@ -10288,6 +10343,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -11042,6 +11102,14 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "requires": {
+        "random-bytes": "~1.0.0"
       }
     },
     "undefsafe": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/WCRI56-Team-GS/Scratch-Project#readme",
   "dependencies": {
-    "cookie-parser": "^1.4.6",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-session": "^1.17.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.2",

--- a/server/controllers/sessionController.js
+++ b/server/controllers/sessionController.js
@@ -3,50 +3,77 @@ const Session = require("../models/sessionModel");
 const sessionController = {};
 
 /**
- * isLoggedIn - find the appropriate session for this request in the database, then
+ * isLoggedIn - find the appropriate session for this request in the sessions obj, then
  * verify whether or not the session is still valid.
  */
-sessionController.isLoggedIn = (req, res, next) => {
-  console.log("running sessionControlled.isLoggedIn");
-  // get SSID from cookie on request
-  console.log("ssid cookie_id: ", req.cookies.ssid);
-
-  // query the DB for a matching cookieID in the session document
-  Session.findOne({ cookieId: req.cookies.ssid })
-    .then((session) => {
-      console.log('query returned: ', session)
-      // if there is a match - We're LOGGED IN - return next();
-      if (session && session.cookieId === req.cookies.ssid) {
-        console.log('Session.cookie matches req.cookies.ssid.  User isLoggedIn.  Moving on to next middleware')
-        return next();
-      }
-      else {
-        return next('No Session.cookie matches req.cookies.ssid.  User NOT logged in.');
-      }
-    })
-    // if no match, redirect or something.  FAIL.
-    .catch((err) => {
-      return next({
-        log: "error in sessionController.isLoggedIn",
-        message: { err: "sessionController.isLoggedIn" + err },
-      });
-    });
-
-  // Session.findOne({ cookieId: req.cookies.ssid}, (err, session) => {
-  //   if (err) {
-  //     // DB error
-  //     return next('Error in sessionController.isLoggedIn: ' + JSON.stringify(err));
-  //   }
-  //   else if (!session) {
-  //     // no session found (session = null)
-  //     res.redirect('/signup');
-  //   }
-  //   else {
-  //     // session found
-  //     return next();
-  //   }
-  // })
+sessionController.validateSession = (req, res, next) => {
+  console.log("validating session with req: ", res.session);
+  // if loggedIn on the request session is truthy
+  if (req.session.loggedIn) {
+    // package information from the session object for front end
+    // TODO - check for structure desired for frontend auth / session management
+    res.locals = {
+      username: req.session.username,
+      email: req.session.email,
+      loggedIn: req.session.loggedIn,
+    };
+    // if the session isn't active, send false for loggedIn back to the front end
+  } else {
+    res.locals.loggedIn = false;
+  }
 };
+
+/**
+ * deleteSession - delete a session from the sessions object
+ *
+ */
+sessionController.deleteSession = (req, res, next) => {
+  console.log("deleting session...");
+  req.session.destroy(next);
+};
+
+// OLD AUTH CODE
+// sessionController.isLoggedIn = (req, res, next) => {
+//   console.log("running sessionControlled.isLoggedIn");
+//   // get SSID from cookie on request
+//   console.log("ssid cookie_id: ", req.cookies.ssid);
+
+//   // query the DB for a matching cookieID in the session document
+//   Session.findOne({ cookieId: req.cookies.ssid })
+//     .then((session) => {
+//       console.log('query returned: ', session)
+//       // if there is a match - We're LOGGED IN - return next();
+//       if (session && session.cookieId === req.cookies.ssid) {
+//         console.log('Session.cookie matches req.cookies.ssid.  User isLoggedIn.  Moving on to next middleware')
+//         return next();
+//       }
+//       else {
+//         return next('No Session.cookie matches req.cookies.ssid.  User NOT logged in.');
+//       }
+//     })
+//     // if no match, redirect or something.  FAIL.
+//     .catch((err) => {
+//       return next({
+//         log: "error in sessionController.isLoggedIn",
+//         message: { err: "sessionController.isLoggedIn" + err },
+//       });
+//     });
+
+// Session.findOne({ cookieId: req.cookies.ssid}, (err, session) => {
+//   if (err) {
+//     // DB error
+//     return next('Error in sessionController.isLoggedIn: ' + JSON.stringify(err));
+//   }
+//   else if (!session) {
+//     // no session found (session = null)
+//     res.redirect('/signup');
+//   }
+//   else {
+//     // session found
+//     return next();
+//   }
+// })
+// };
 
 /**
  * startSession - create and save a new Session into the database.


### PR DESCRIPTION
Removed cookie-controller to avoid express-session conflicts
Left cookieController middleware, but can delete once we've finished the SQL login refactor and connected to front-end login to confirm that backend auth is functioning. 
Note: added lines of code with comments into login and create user middlewares that will need to be included after the SQL refactor for auth to work.
Additional data can be stored in sessions to be passed to the front end on login/verification if desired.